### PR TITLE
compatible with redmine 4.2.3 version

### DIFF
--- a/assets/javascripts/select2-3.4.5/select2.js
+++ b/assets/javascripts/select2-3.4.5/select2.js
@@ -354,6 +354,11 @@ the specific language governing permissions and limitations under the Apache Lic
                 }
             });
         }
+        
+        if ($.inArray('value', replacements) >= 0) {
+            replacements.splice($.inArray('value', replacements), 1);
+        }
+        
         dest.attr("class", replacements.join(" "));
     }
 


### PR DESCRIPTION
Fix the problem that the second option is not displayed when switching filter conditions
For example: when the selection status is "not equal to", the specific filter condition is display
<img width="950" alt="image" src="https://user-images.githubusercontent.com/21010051/166143595-54c6ce99-16d8-4b8d-9d34-26ecc1296f05.png">